### PR TITLE
Fix quota calculation

### DIFF
--- a/sophomorix-samba/scripts/sophomorix-cacls
+++ b/sophomorix-samba/scripts/sophomorix-cacls
@@ -179,7 +179,7 @@ foreach my $linux_path (@linux_paths){
                      " -U ".$user."%`cat /etc/linuxmuster/.secret/administrator` ".$smb_unc." -c 'allinfo \"".$smb_rel."\"'";
             } elsif ($stat==1){
                 $command=$sophomorix_config{'INI'}{'EXECUTABLES'}{'SMBCLIENT'}.
-                     " -U ".$user."%`cat /etc/linuxmuster/.secret/administrator` ".$smb_unc." -mNT1 -c 'stat \"".$smb_rel."\"'";
+                     " -U ".$user."%`cat /etc/linuxmuster/.secret/administrator` ".$smb_unc." -c 'stat \"".$smb_rel."\"'";
             } elsif ($ls==1){
                 $command=$sophomorix_config{'INI'}{'EXECUTABLES'}{'SMBCLIENT'}.
                      " -U ".$user."%`cat /etc/linuxmuster/.secret/administrator` ".$smb_unc." -c 'cd \"".$smb_rel."\"; ls'";

--- a/sophomorix-samba/scripts/sophomorix-query
+++ b/sophomorix-samba/scripts/sophomorix-query
@@ -1065,7 +1065,7 @@ for( my $index = 0 ; $index < $max ; $index++) {
     if (defined $options{'quota-usage'}){
         foreach my $sophomorix_quota (@{$search{$top_key}{$sam}{'sophomorixQuota'} }){
             my ($share,$value,$oldcalc,$quotastatus,$comment)=split(/:/,$sophomorix_quota);
-            my $smbcquotas_command="/usr/bin/smbcquotas -mNT1 -U administrator%`cat /etc/linuxmuster/.secret/administrator`".
+            my $smbcquotas_command="/usr/bin/smbcquotas -U administrator%`cat /etc/linuxmuster/.secret/administrator`".
                 " -u $sam //".$root_dns."/".$share." 2> /dev/null";
             #print "   $smbcquotas_command\n";
             # run the command


### PR DESCRIPTION
The option NT1 is not supported anymore and cause many problems on file transfer or quota calculation.
The posix functionalities are not maintained anymore in samba, so we should remove it and find another solution.

Removing the NT1 option in sophomorix-query fixs the quota problem.

I removed the option NT1 in sophomorix-cacls too, but didn't test it.