### PR TITLE
Escape special chars in footer

### DIFF
--- a/sophomorix-samba/scripts/sophomorix-print
+++ b/sophomorix-samba/scripts/sophomorix-print
@@ -814,8 +814,9 @@ sub latex_from_template_and_datablock {
         }
  
         # (use hyphen here for template)
+	my $filename_footer=&string_to_latex($output_file_basename);
         $line=~s/\\textcolor\{red\}\{SCHOOL-LONGNAME\}/$schoolstring/;
-        $line=~s/\\textcolor\{red\}\{FILENAME\}/$output_file_basename/;
+        $line=~s/\\textcolor\{red\}\{FILENAME\}/$filename_footer/;
         $line=~s/\\textcolor\{red\}\{ADMINS-PRINT\}/$admins_print/;
 
 


### PR DESCRIPTION
The string `$output_file_basename` is directly used in the footer and can lead to compilation problem with some special chars, like e.g. `_` (if a schoolclass contains an underscore).
Filtering it can avoid this kind of problems.