### PR TITLE
Enhanced detection of user's room in sophomorix-query

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.4
 Package: sophomorix-samba
 Architecture: all
 Pre-Depends: ldb-tools, libconfig-inifiles-perl, libnet-dns-perl, libnet-ldap-perl
-Depends: libnss-winbind, libunicode-map8-perl, libnet-mac-perl, libnet-ldap-sid-perl, libdate-calc-perl, liblist-moreutils-perl, libstring-approx-perl, libjson-perl, libmath-round-perl, libfilesys-smbclient-perl, libhtml-tableextract-perl, liblatex-encode-perl, libterm-readkey-perl, libparallel-forkmanager-perl, cifs-utils, texlive-latex-base, texlive-fonts-recommended, texlive-lang-german
+Depends: libnss-winbind, libunicode-map8-perl, libnet-mac-perl, libnet-ldap-sid-perl, libnetaddr-ip-perl, libdate-calc-perl, liblist-moreutils-perl, libstring-approx-perl, libjson-perl, libmath-round-perl, libfilesys-smbclient-perl, libhtml-tableextract-perl, liblatex-encode-perl, libterm-readkey-perl, libparallel-forkmanager-perl, cifs-utils, texlive-latex-base, texlive-fonts-recommended, texlive-lang-german
 Description: Sophomorix for Samba 4
  sophomorix-samba is a user management tool for Samba 4
 

--- a/development/debian-packages
+++ b/development/debian-packages
@@ -1,6 +1,7 @@
 # all
 DONE:libnet-ldap-perl              # Net::ldap
 DONE libunicode-map8-perl          # password generation
+DONE libnetaddr-ip-perl            # IP subnet checks
 
 # developer
 ldap-utils

--- a/sophomorix-samba/scripts/sophomorix-query
+++ b/sophomorix-samba/scripts/sophomorix-query
@@ -18,6 +18,8 @@ $Data::Dumper::Terse = 1;
 use JSON;
 use Sophomorix::SophomorixBase qw(
                                  analyze_smbcquotas_out
+                                 result_sophomorix_init
+                                 config_sophomorix_read
                                  );
 use Sophomorix::SophomorixSambaAD qw(
                                  AD_bind_admin
@@ -80,6 +82,7 @@ my $testopt=GetOptions(\%options,
                         "query-ip=s",
                         "query-comp=s",
                         "query-user=s",
+                        "prefer-ip=s",
                         "query-room=s"
     );
 
@@ -182,6 +185,7 @@ Query room data with smbstatus command:
 --smbstatus --query-ip <ip>       (show room that contains computer with <ip>)
 --smbstatus --query-comp <comp>   (show room that contains computer <comp>)
 --smbstatus --query-user <user>   (show room where <user> is logged in)
+    --prefer-ip <ip>              (optional: if there is a smb connection for <user> from <ip>, prefer it)
 --smbstatus --query-room <room>   (show room <room>)
 
 Limit the query to one or more sophomorixStatus:
@@ -362,6 +366,20 @@ if (defined $options{'smbstatus'}){
     #my $string=`cat /root/log1`;
     my @lines=split("\n",$string);
     #print "$string";
+    my $prefered_ip=NetAddr::IP->new("0.0.0.0/0");
+    if (defined $options{'prefer-ip'}){
+        $prefered_ip=NetAddr::IP->new($options{'prefer-ip'})
+    }
+    # TODO (XRM): get ignored ips or the file itself from config
+    my $ignored_networks_file="/etc/linuxmuster/sophomorix/sophomorix-query.ignored_nets.txt";
+    my @ignored_networks=();
+    my $count=0;
+    open(IGNORED_NETWORKS,"$ignored_networks_file") ||
+        die "ERROR: $ignored_networks_file not found!";
+    while(<IGNORED_NETWORKS>){
+        $ignored_networks[$count++] = NetAddr::IP->new($_);
+    }
+    close(IGNORED_NETWORKS);
     # first loop: get computers
     foreach my $entry (@lines){
         my ($pid)=split(/ /,$entry);
@@ -381,10 +399,28 @@ if (defined $options{'smbstatus'}){
                $entry=~m/\\domain computers\s+([0-9.].*)\s+\(/;
                my $ip=$1;
 
+               # ignore devices that are listed in ignore-list
+               my $net_ip = NetAddr::IP->new($ip);
+               my $ip_within_net = 0;
+               foreach my $network (@ignored_networks) {
+                   if ($net_ip->within($network)) {
+                       $ip_within_net = 1;
+                       last;
+                   }
+               }
+               if ($ip_within_net == 1) {
+                   next;
+               }
+
                # extract ipv4 from line
                $entry=~m/ipv4:([0-9.].*)\)/;
                my $ipv4_port=$1;
                my ($ipv4,$port)=split(/:/,$ipv4_port);
+
+               # If a prefered ip is given, reconsider the current entry.
+               if (exists $smbstatus{'USER'}{$user} and !($net_ip->within($prefered_ip))) {
+                   next;
+               }
 
                # Save Data
                $smbstatus{'COMPUTER'}{$computer}{'SMBSTATUS_LINE'}=$entry;


### PR DESCRIPTION
Changes that make it possible to ... :
- ... give a list of IPs/networks that should be ignored in sophomorix-query.
- ... give a "prefered" IP, i.e. one, that will be preferred if there are multiple connections for a user.

The first option is used to block out any servers that open SMB connections on behalf of the user (for example Nextcloud servers) and that should be ignored when determining the user's room.

The second option can be used by the WebUI (PR will follow if/when this PR is accepted) to pass the user's IP address to the script. If a user has a SMB connection from that IP, it will be used for room detection, else it will be ignored.

Notes on the PR:
- not sure if I correctly added the dependency on `libnetaddr-ip-perl`. If not, I'll happily adjust it.
- The list of IPs/networks is currently hardcoded to reside within `/etc/linuxmuster/sophomorix/sophomorix-query.ignored_nets.txt`. It is most likely better pratice to store this in `sophomorix_config` but I am unsure on how to add it there.

Related links: https://ask.linuxmuster.net/t/konsole-aktueller-raum-durch-nextcloud-irritiert/10438/4

I am not sure if this is helpful at all as I am neither used to write Perl nor skilled in the LMN-coding style. I do hope it is, but sorry if not ...