### PR TITLE
support printing classes with underscores

### DIFF
--- a/sophomorix-samba/scripts/sophomorix-print
+++ b/sophomorix-samba/scripts/sophomorix-print
@@ -814,8 +814,9 @@ sub latex_from_template_and_datablock {
         }
  
         # (use hyphen here for template)
+        my $output_file_basename_print=&string_to_latex($output_file_basename);
         $line=~s/\\textcolor\{red\}\{SCHOOL-LONGNAME\}/$schoolstring/;
-        $line=~s/\\textcolor\{red\}\{FILENAME\}/$output_file_basename/;
+        $line=~s/\\textcolor\{red\}\{FILENAME\}/$output_file_basename_print/;
         $line=~s/\\textcolor\{red\}\{ADMINS-PRINT\}/$admins_print/;
 
 


### PR DESCRIPTION
underscores in classes are handled, except for this small regexp.

Part of $output_file_basename is the class, which makes latex fail, if the classname has underscores.