### PR TITLE
Fix Projects in Installation with custom workgroup not beeing deletable

### DIFF
--- a/sophomorix-samba/modules/SophomorixSambaAD.pm
+++ b/sophomorix-samba/modules/SophomorixSambaAD.pm
@@ -1557,6 +1557,7 @@ sub AD_group_kill {
 
                 my $smb = new Filesys::SmbClient(username  => $DevelConf::sophomorix_file_admin,
                                                  password  => $smb_admin_pass,
+												 workgroup => $ref_sophomorix_config->{'samba'}{'smb.conf'}{'global'}{'workgroup'},
                                                  debug     => 0);
 
                 my $return1=$smb->rmdir_recurse($smb_share);


### PR DESCRIPTION
See: https://ask.linuxmuster.net/t/projekte-lassen-sich-nicht-loeschen/11252/8 for a discussion of the issue.
With this line deleting projects within a multischool installation with differing workgroup name works.

A proper fix would probably not use Filesys::SmbClient at all, but it works.,