### PR TITLE
Add manual mail schema

### DIFF
--- a/sophomorix-samba/modules/SophomorixSambaAD.pm
+++ b/sophomorix-samba/modules/SophomorixSambaAD.pm
@@ -5893,7 +5893,10 @@ sub AD_create_new_mail {
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "lastname.firstname"){
 	    $mail_local_part=$lastname.".".$firstname;
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "manual"){
-        return $mail_old;
+        if ($mail_old ne "") {
+            return $mail_old;
+        }
+        $mail_local_part=$sam;
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} ne ""){
         my $error_message="$ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} not allowed as 'MAIL_LOCAL_PART_SCHEME' in school '".$school_file.
                           "' | Allowed: firstname|lastname|firstname.lastname|lastname.firstname|manual";

--- a/sophomorix-samba/modules/SophomorixSambaAD.pm
+++ b/sophomorix-samba/modules/SophomorixSambaAD.pm
@@ -5848,7 +5848,8 @@ sub AD_create_new_mail {
 	$lastname_old,
 	$lastname_new,
 	$filename_new,
-	$class_new) = @_;
+	$class_new,
+    $mail_old) = @_;
 
     my $firstname;
     if ($firstname_new ne "---"){
@@ -5884,16 +5885,18 @@ sub AD_create_new_mail {
     my $mail_local_part;
     $mail_local_part=$sam; # default
     if ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "firstname"){
-	$mail_local_part=$firstname;
+	    $mail_local_part=$firstname;
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "lastname"){
-	$mail_local_part=$lastname;
+	    $mail_local_part=$lastname;
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "firstname.lastname"){
-	$mail_local_part=$firstname.".".$lastname;
+	    $mail_local_part=$firstname.".".$lastname;
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "lastname.firstname"){
-	$mail_local_part=$lastname.".".$firstname;
-    } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} ne ""){
+	    $mail_local_part=$lastname.".".$firstname;
+    } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "manual"){
+        return $mail_old;
+    }elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} ne ""){
         my $error_message="$ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} not allowed as 'MAIL_LOCAL_PART_SCHEME' in school '".$school_file.
-                          "' | Allowed: firstname|lastname|firstname.lastname|lastname.firstname";
+                          "' | Allowed: firstname|lastname|firstname.lastname|lastname.firstname|manual";
         &Sophomorix::SophomorixBase::log_script_exit($error_message,1,1,0,
                          $ref_arguments,$ref_sophomorix_result,$ref_sophomorix_config,$json);
 

--- a/sophomorix-samba/modules/SophomorixSambaAD.pm
+++ b/sophomorix-samba/modules/SophomorixSambaAD.pm
@@ -5894,12 +5894,11 @@ sub AD_create_new_mail {
 	    $mail_local_part=$lastname.".".$firstname;
     } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} eq "manual"){
         return $mail_old;
-    }elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} ne ""){
+    } elsif ($ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} ne ""){
         my $error_message="$ref_sophomorix_config->{'ROLES'}{$school}{$role}{'MAIL_LOCAL_PART_SCHEME'} not allowed as 'MAIL_LOCAL_PART_SCHEME' in school '".$school_file.
                           "' | Allowed: firstname|lastname|firstname.lastname|lastname.firstname|manual";
         &Sophomorix::SophomorixBase::log_script_exit($error_message,1,1,0,
                          $ref_arguments,$ref_sophomorix_result,$ref_sophomorix_config,$json);
-
     }
 
     # override MAIL_LOCAL_PART by MAIL_LOCAL_PART_MAP, if there

--- a/sophomorix-samba/scripts/sophomorix-check
+++ b/sophomorix-samba/scripts/sophomorix-check
@@ -1656,7 +1656,8 @@ sub test_user_update {
                                            ${$old_surname_ascii_ref},
                                            ${$new_surname_ascii_ref},
 	                                   $Match{$school}{'ACTION'}{$line_new}{'filename'},
-	                                   $adminclass);
+	                                   $adminclass,
+                                       ${$old_mail_ref});
     # test for update
     if ( ${$new_mail_ref} eq  ${$old_mail_ref} ){
         # no update


### PR DESCRIPTION
Pull request originally from @hermanntoast:

For some roles, it is necessary to set a custom mail-address or a custom mail-schema. This can be done manually or with some hook scripts. The manual changes are overwritten by sophomorix every time, so I add the option so set the local part-schema to "manual" to keep the existing mail-address. If no mail-address exists, it falls back to the SamAccountName.